### PR TITLE
Internal: executor integration tests

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -72,6 +72,7 @@ testing =
     pytest-asyncio
     pytest-cov
     pytest-mock
+    uvicorn
 
 [options.entry_points]
 # Add here console scripts like:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,5 +6,94 @@
     - https://docs.pytest.org/en/stable/fixture.html
     - https://docs.pytest.org/en/stable/writing_plugins.html
 """
+import multiprocessing
+import os
+import socket
+from contextlib import contextmanager
+from time import sleep
+from typing import Union
 
-# import pytest
+import aiohttp
+import fastapi.applications
+import pytest
+import pytest_asyncio
+import uvicorn
+
+from aleph_vrf.settings import settings
+from mock_ccn import app as mock_ccn_app
+
+
+def wait_for_server(host: str, port: int, nb_retries: int = 3, wait_time: int = 0.1):
+    sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    sock.settimeout(5)
+
+    retries = 0
+    while retries < nb_retries:
+        try:
+            sock.connect((host, port))
+        except ConnectionError:
+            retries += 1
+            sleep(wait_time)
+            continue
+
+        break
+
+
+@contextmanager
+def run_http_app(
+    app: Union[str, fastapi.applications.ASGIApp], host: str, port: int
+) -> multiprocessing.Process:
+    uvicorn_process = multiprocessing.Process(
+        target=uvicorn.run, args=(app,), kwargs={"host": host, "port": port}
+    )
+    uvicorn_process.start()
+
+    try:
+        # Wait for uvicorn to start
+        wait_for_server(host, port)
+        yield uvicorn_process
+
+    finally:
+        uvicorn_process.terminate()
+        uvicorn_process.join()
+
+
+@pytest.fixture
+def mock_ccn() -> str:
+    host, port = "127.0.0.1", 4024
+    url = f"http://{host}:{port}"
+
+    default_api_host = settings.API_HOST
+
+    # Configure the mock CCN as API host. Note that `settings` must be modified as the object is
+    # already built when running all tests in the same run.
+    os.environ["ALEPH_VRF_API_HOST"] = url
+    settings.API_HOST = url
+
+    with run_http_app(app=mock_ccn_app, host=host, port=port):
+        yield url
+
+    # Clean up settings for other tests
+    del os.environ["ALEPH_VRF_API_HOST"]
+    settings.API_HOST = default_api_host
+
+
+@pytest_asyncio.fixture
+async def mock_ccn_client(mock_ccn: str):
+    async with aiohttp.ClientSession(mock_ccn) as client:
+        yield client
+
+
+@pytest.fixture
+def executor_server(mock_ccn: str) -> str:
+    assert mock_ccn, "The mock CCN server must be running"
+
+    host, port = "127.0.0.1", 8081
+    with run_http_app(app="aleph_vrf.executor.main:app", host=host, port=port):
+        yield f"http://{host}:{port}"
+
+
+@pytest_asyncio.fixture
+async def executor_client(executor_server: str) -> aiohttp.ClientSession:
+    async with aiohttp.ClientSession(executor_server) as client:
+        yield client

--- a/tests/executor/test_integration.py
+++ b/tests/executor/test_integration.py
@@ -1,0 +1,285 @@
+import datetime as dt
+from hashlib import sha256
+from typing import Dict, Any, Union, Tuple
+
+import aiohttp
+import pytest
+import pytest_asyncio
+from aleph.sdk import AlephClient
+from aleph_message.models import (
+    ItemType,
+    MessageType,
+    PostContent,
+    Chain,
+    ItemHash,
+    PostMessage,
+)
+
+from aleph_vrf.models import VRFRequest, VRFResponseHash, VRFResponse, VRFRandomBytes
+from aleph_vrf.utils import binary_to_bytes, verify
+
+
+@pytest.mark.asyncio
+async def test_mock(mock_ccn: str):
+    """
+    Sanity check test: verify that the mock CCN can be started.
+    """
+
+    async with aiohttp.ClientSession(mock_ccn) as ccn_client:
+        messages = await ccn_client.get("/api/v0/messages")
+        assert messages
+
+
+MessageDict = Dict[str, Any]
+
+
+def make_post_message(
+    vrf_object: Union[VRFRequest, VRFResponse], sender: str
+) -> MessageDict:
+    content = PostContent(
+        type="vrf_library_post",
+        ref=f"vrf_{vrf_object.request_id}_request",
+        address=sender,
+        time=dt.datetime(2023, 1, 1, tzinfo=dt.timezone.utc).timestamp(),
+        content=vrf_object,
+    )
+
+    item_content = content.json()
+    item_hash = sha256(item_content.encode()).hexdigest()
+
+    return {
+        "item_hash": item_hash,
+        "type": MessageType.post.value,
+        "chain": Chain.ETH.value,
+        "sender": sender,
+        "signature": "fake-sig",
+        "item_type": ItemType.inline.value,
+        "item_content": item_content,
+        "channel": f"vrf_{vrf_object.request_id}",
+        "time": content.time,
+    }
+
+
+@pytest.fixture
+def mock_vrf_request() -> VRFRequest:
+    request_id = "513eb52c-cb74-463a-b40e-0e2adedafb8b"
+
+    vrf_request = VRFRequest(
+        nb_bytes=32,
+        nb_executors=4,
+        nonce=42,
+        vrf_function="deca" * 16,
+        request_id=request_id,
+        node_list_hash="1234",
+    )
+    return vrf_request
+
+
+@pytest_asyncio.fixture
+async def published_vrf_request(
+    mock_ccn_client: aiohttp.ClientSession, mock_vrf_request: VRFRequest
+) -> Tuple[MessageDict, VRFRequest]:
+    sender = "aleph_vrf_coordinator"
+    message_dict = make_post_message(mock_vrf_request, sender=sender)
+
+    resp = await mock_ccn_client.post(
+        "/api/v0/messages",
+        json={"message": message_dict, "sync": True},
+    )
+    assert resp.status == 200, await resp.text()
+    return message_dict, mock_vrf_request
+
+
+def assert_vrf_hash_matches_request(
+    response_hash: VRFResponseHash, vrf_request: VRFRequest, request_item_hash: ItemHash
+):
+    assert response_hash.nb_bytes == vrf_request.nb_bytes
+    assert response_hash.nonce == vrf_request.nonce
+    assert response_hash.request_id == vrf_request.request_id
+    assert response_hash.execution_id  # This should be a UUID4
+    assert response_hash.vrf_request == request_item_hash
+    assert response_hash.random_bytes_hash
+    assert response_hash.message_hash
+
+
+def assert_random_number_matches_request(
+    random_bytes: VRFRandomBytes,
+    response_hash: VRFResponseHash,
+    vrf_request: VRFRequest,
+):
+    assert random_bytes.request_id == vrf_request.request_id
+    assert random_bytes.execution_id == response_hash.execution_id
+    assert random_bytes.vrf_request == response_hash.vrf_request
+    assert random_bytes.random_bytes_hash == response_hash.random_bytes_hash
+
+    assert verify(
+        random_bytes=binary_to_bytes(random_bytes.random_bytes),
+        nonce=vrf_request.nonce,
+        random_hash=response_hash.random_bytes_hash,
+    )
+
+
+def assert_vrf_response_hash_equal(
+    response_hash: VRFResponseHash, expected_response_hash: VRFResponseHash
+):
+    assert response_hash.nb_bytes == expected_response_hash.nb_bytes
+    assert response_hash.nonce == expected_response_hash.nonce
+    assert response_hash.request_id == expected_response_hash.request_id
+    assert response_hash.execution_id == expected_response_hash.execution_id
+    assert response_hash.vrf_request == expected_response_hash.vrf_request
+    assert response_hash.random_bytes_hash == expected_response_hash.random_bytes_hash
+    # We do not check message_hash as it can be None in the aleph message but set in the API response
+
+
+async def assert_aleph_message_matches_response_hash(
+    ccn_url: str, response_hash: VRFResponseHash
+) -> PostMessage:
+    assert response_hash.message_hash
+
+    async with AlephClient(api_server=ccn_url) as client:
+        message = await client.get_message(
+            response_hash.message_hash, message_type=PostMessage
+        )
+
+    message_response_hash = VRFResponseHash.parse_obj(message.content.content)
+    assert_vrf_response_hash_equal(message_response_hash, response_hash)
+
+    return message
+
+
+def assert_vrf_random_bytes_equal(
+    random_bytes: VRFRandomBytes, expected_random_bytes: VRFRandomBytes
+):
+    assert random_bytes.request_id == expected_random_bytes.request_id
+    assert random_bytes.execution_id == expected_random_bytes.execution_id
+    assert random_bytes.vrf_request == expected_random_bytes.vrf_request
+    assert random_bytes.random_bytes == expected_random_bytes.random_bytes
+    assert random_bytes.random_bytes_hash == expected_random_bytes.random_bytes_hash
+    assert random_bytes.random_number == expected_random_bytes.random_number
+    # We do not check message_hash as it can be None in the aleph message but set in the API response
+
+
+async def assert_aleph_message_matches_random_bytes(
+    ccn_url: str, random_bytes: VRFRandomBytes
+) -> PostMessage:
+    assert random_bytes.message_hash
+
+    async with AlephClient(api_server=ccn_url) as client:
+        message = await client.get_message(
+            random_bytes.message_hash, message_type=PostMessage
+        )
+
+    message_random_bytes = VRFRandomBytes.parse_obj(message.content.content)
+    assert_vrf_random_bytes_equal(message_random_bytes, random_bytes)
+
+    return message
+
+
+@pytest.mark.asyncio
+async def test_normal_request_flow(
+    mock_ccn_client: aiohttp.ClientSession,
+    executor_client: aiohttp.ClientSession,
+    published_vrf_request: Tuple[MessageDict, VRFRequest],
+):
+    """
+    Test that the executor works under normal circumstances:
+    1. The coordinator publishes a request message
+    2. The coordinator calls /generate
+    3. The coordinator calls /publish.
+    """
+
+    message_dict, vrf_request = published_vrf_request
+    item_hash = message_dict["item_hash"]
+
+    resp = await executor_client.post(f"/generate/{item_hash}")
+    assert resp.status == 200, await resp.text()
+    response_json = await resp.json()
+
+    response_hash = VRFResponseHash.parse_obj(response_json["data"])
+
+    assert_vrf_hash_matches_request(response_hash, vrf_request, item_hash)
+    random_hash_message = await assert_aleph_message_matches_response_hash(
+        mock_ccn_client._base_url, response_hash
+    )
+
+    resp = await executor_client.post(f"/publish/{response_hash.message_hash}")
+    assert resp.status == 200, await resp.text()
+    response_json = await resp.json()
+
+    random_bytes = VRFRandomBytes.parse_obj(response_json["data"])
+    assert_random_number_matches_request(
+        random_bytes=random_bytes,
+        response_hash=response_hash,
+        vrf_request=vrf_request,
+    )
+    random_number_message = await assert_aleph_message_matches_random_bytes(
+        mock_ccn_client._base_url, random_bytes
+    )
+
+    # Sanity checks on the message
+    assert random_number_message.sender == random_hash_message.sender
+    assert random_number_message.chain == random_hash_message.chain
+
+
+@pytest.mark.asyncio
+async def test_call_publish_twice(
+    executor_client: aiohttp.ClientSession,
+    published_vrf_request: Tuple[MessageDict, VRFRequest],
+):
+    """
+    Test that the executor will only return data the first time POST /publish is called.
+    This feature makes it possible for the coordinator to detect that someone else already received
+    the generated random number.
+    """
+    message_dict, vrf_request = published_vrf_request
+    item_hash = message_dict["item_hash"]
+
+    resp = await executor_client.post(f"/generate/{item_hash}")
+    assert resp.status == 200, await resp.text()
+    response_json = await resp.json()
+
+    response_hash = VRFResponseHash.parse_obj(response_json["data"])
+
+    # Call POST /publish a first time
+    resp = await executor_client.post(f"/publish/{response_hash.message_hash}")
+    assert resp.status == 200, await resp.text()
+
+    # Call it a second time
+    resp = await executor_client.post(f"/publish/{response_hash.message_hash}")
+    assert resp.status == 404, await resp.text()
+
+
+@pytest.mark.asyncio
+async def test_call_generate_twice(
+    executor_client: aiohttp.ClientSession,
+    published_vrf_request: Tuple[MessageDict, VRFRequest],
+):
+    """
+    Test that calling POST /generate twice with the same request does not generate a new random number.
+    We expect the API to return the same random number.
+    """
+    message_dict, vrf_request = published_vrf_request
+    item_hash = message_dict["item_hash"]
+
+    # Call POST /generate a first time
+    resp = await executor_client.post(f"/generate/{item_hash}")
+    assert resp.status == 200, await resp.text()
+
+    # Call POST /generate a second time
+    resp = await executor_client.post(f"/generate/{item_hash}")
+    assert resp.status == 409, await resp.text()
+
+
+@pytest.mark.asyncio
+async def test_call_generate_without_aleph_message(
+    executor_client: aiohttp.ClientSession,
+    mock_vrf_request: VRFRequest,
+):
+    """
+    Test that calling POST /generate without an aleph message fails.
+    """
+    item_hash = "bad0" * 16
+
+    # Call POST /generate with a nonexistent item hash
+    resp = await executor_client.post(f"/generate/{item_hash}")
+    assert resp.status == 404, await resp.text()

--- a/tests/mock_ccn.py
+++ b/tests/mock_ccn.py
@@ -1,0 +1,72 @@
+import json
+import logging
+from enum import Enum
+from typing import Optional, Dict, Any, List
+
+from aleph_message.status import MessageStatus
+from fastapi import FastAPI
+from pydantic import BaseModel, Field
+
+logger = logging.getLogger(__name__)
+
+app = FastAPI()
+
+
+MESSAGES = {}
+
+
+@app.get("/api/v0/messages.json")
+async def get_messages(hashes: Optional[str], page: int = 1, pagination: int = 20):
+    hashes = hashes.split(",")
+    messages = [MESSAGES[item_hash] for item_hash in hashes if item_hash in MESSAGES]
+    paginated_messages = messages[(page - 1) * pagination : page * pagination]
+
+    return {
+        "messages": paginated_messages,
+        "pagination_page": page,
+        "pagination_per_page": pagination,
+        "pagination_total": len(messages),
+        "pagination_item": "messages",
+    }
+
+
+class PubMessageRequest(BaseModel):
+    sync: bool = False
+    message_dict: Dict[str, Any] = Field(alias="message")
+
+
+class Protocol(str, Enum):
+    """P2P Protocol"""
+
+    IPFS = "ipfs"
+    P2P = "p2p"
+
+
+class PublicationStatus(BaseModel):
+    status: str
+    failed: List[Protocol]
+
+
+class PubMessageResponse(BaseModel):
+    publication_status: PublicationStatus
+    message_status: Optional[MessageStatus]
+
+
+def format_message(message_dict: Dict[str, Any]):
+    if message_dict["item_type"] == "inline":
+        message_dict["content"] = json.loads(message_dict["item_content"])
+
+    message_dict["size"] = len(message_dict["item_content"])
+
+
+@app.post("/api/v0/messages", response_model=PubMessageResponse)
+async def post_message(message_request: PubMessageRequest):
+    global MESSAGES
+
+    format_message(message_request.message_dict)
+    MESSAGES[message_request.message_dict["item_hash"]] = message_request.message_dict
+
+    return PubMessageResponse(
+        publication_status=PublicationStatus(status="success", failed=[]),
+        message_status=MessageStatus.PROCESSED,
+    )


### PR DESCRIPTION
Added integration tests for the executor. These tests start the executor as a separate process, along with a mock CCN to avoid publishing on the production aleph.im network. 