### PR TITLE
Internal: check typing with mypy

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -3,7 +3,7 @@ name: Unit tests
 on: [push]
 
 jobs:
-  build:
+  tests:
 
     runs-on: ubuntu-22.04
     strategy:
@@ -20,6 +20,9 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -e .[testing]
+      - name: Check typing with mypy
+        run: |
+          mypy src/ tests/
       - name: Test with pytest
         run: |
           pytest

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,0 +1,65 @@
+# Global options:
+
+[mypy]
+mypy_path = src
+
+exclude = conftest.py
+
+
+show_column_numbers = True
+
+# Suppressing errors
+# Shows errors related to strict None checking, if the global strict_optional flag is enabled
+strict_optional = True
+no_implicit_optional = True
+
+# Import discovery
+# Suppresses error messages about imports that cannot be resolved
+ignore_missing_imports = True
+# Forces import to reference the original source file
+no_implicit_reexport = True
+# show error messages from unrelated files
+follow_imports = silent
+follow_imports_for_stubs = False
+
+
+# Disallow dynamic typing
+# Disallows usage of types that come from unfollowed imports
+disallow_any_unimported = False
+# Disallows all expressions in the module that have type Any
+disallow_any_expr = False
+# Disallows functions that have Any in their signature after decorator transformation.
+disallow_any_decorated = False
+# Disallows explicit Any in type positions such as type annotations and generic type parameters.
+disallow_any_explicit = False
+# Disallows usage of generic types that do not specify explicit type parameters.
+disallow_any_generics = False
+# Disallows subclassing a value of type Any.
+disallow_subclassing_any = False
+
+# Untyped definitions and calls
+# Disallows calling functions without type annotations from functions with type annotations.
+disallow_untyped_calls = False
+# Disallows defining functions without type annotations or with incomplete type annotations
+disallow_untyped_defs = False
+# Disallows defining functions with incomplete type annotations.
+check_untyped_defs = False
+# Type-checks the interior of functions without type annotations.
+disallow_incomplete_defs = False
+# Reports an error whenever a function with type annotations is decorated with a decorator without annotations.
+disallow_untyped_decorators = False
+
+# Prohibit comparisons of non-overlapping types (ex: 42 == "no")
+strict_equality = True
+
+# Configuring warnings
+# Warns about unneeded # type: ignore comments.
+warn_unused_ignores = True
+# Shows errors for missing return statements on some execution paths.
+warn_no_return = True
+# Shows a warning when returning a value with type Any from a function declared with a non- Any return type.
+warn_return_any = False
+
+# Miscellaneous strictness flags
+# Allows variables to be redefined with an arbitrary type, as long as the redefinition is in the same block and nesting level as the original definition.
+allow_redefinition = True

--- a/setup.cfg
+++ b/setup.cfg
@@ -67,11 +67,12 @@ exclude =
 
 # Add here test requirements (semicolon/line-separated)
 testing =
-    setuptools
+    mypy==1.5.1
     pytest
     pytest-asyncio
     pytest-cov
     pytest-mock
+    setuptools
     uvicorn
 
 [options.entry_points]

--- a/src/aleph_vrf/coordinator/main.py
+++ b/src/aleph_vrf/coordinator/main.py
@@ -1,4 +1,5 @@
 import logging
+from typing import Dict, Union
 
 logger = logging.getLogger(__name__)
 
@@ -13,7 +14,7 @@ from fastapi import FastAPI
 
 logger.debug("local imports")
 from aleph_vrf.coordinator.vrf import generate_vrf
-from aleph_vrf.models import APIResponse
+from aleph_vrf.models import APIResponse, VRFResponse
 
 logger.debug("imports done")
 
@@ -36,6 +37,8 @@ async def index():
 async def receive_vrf() -> APIResponse:
     private_key = get_fallback_private_key()
     account = ETHAccount(private_key=private_key)
+
+    response: Union[VRFResponse, Dict[str, str]]
 
     try:
         response = await generate_vrf(account)

--- a/src/aleph_vrf/settings.py
+++ b/src/aleph_vrf/settings.py
@@ -3,23 +3,23 @@ from pydantic import BaseSettings, Field
 
 class Settings(BaseSettings):
     API_HOST: str = Field(
-        "https://api2.aleph.im",
+        default="https://api2.aleph.im",
         description="URL of the reference aleph.im Core Channel Node.",
     )
     CORECHANNEL_AGGREGATE_ADDRESS = Field(
-        "0xa1B3bb7d2332383D96b7796B908fB7f7F3c2Be10",
+        default="0xa1B3bb7d2332383D96b7796B908fB7f7F3c2Be10",
         description="Address posting the `corechannel` aggregate.",
     )
     CORECHANNEL_AGGREGATE_KEY = Field(
-        "corechannel", description="Key for the `corechannel` aggregate."
+        default="corechannel", description="Key for the `corechannel` aggregate."
     )
     FUNCTION: str = Field(
-        "4992b4127d296b240bbb73058daea9bca09f717fa94767d6f4dc3ef53b4ef5ce",
+        default="4992b4127d296b240bbb73058daea9bca09f717fa94767d6f4dc3ef53b4ef5ce",
         description="VRF function to use.",
     )
-    NB_EXECUTORS: int = Field(32, description="Number of executors to use.")
+    NB_EXECUTORS: int = Field(default=32, description="Number of executors to use.")
     NB_BYTES: int = Field(
-        32, description="Number of bytes of the generated random number."
+        default=32, description="Number of bytes of the generated random number."
     )
 
     class Config:

--- a/src/aleph_vrf/utils.py
+++ b/src/aleph_vrf/utils.py
@@ -1,6 +1,6 @@
 from hashlib import sha3_256
 from random import randint
-from typing import List
+from typing import List, Tuple
 
 from utilitybelt import dev_urandom_entropy
 
@@ -38,9 +38,9 @@ def generate_nonce() -> int:
     return randint(0, 100000000)
 
 
-def generate(n: int, nonce: int) -> (bytes, bytes):
+def generate(n: int, nonce: int) -> Tuple[bytes, str]:
     """Generates a number of random bytes and hashes them with the nonce."""
-    random_bytes = dev_urandom_entropy(n)
+    random_bytes: bytes = dev_urandom_entropy(n)
     random_hash = sha3_256(random_bytes + int_to_bytes(nonce)).hexdigest()
     return random_bytes, random_hash
 

--- a/tests/mock_ccn.py
+++ b/tests/mock_ccn.py
@@ -3,6 +3,7 @@ import logging
 from enum import Enum
 from typing import Optional, Dict, Any, List
 
+from aleph_message.models import ItemHash
 from aleph_message.status import MessageStatus
 from fastapi import FastAPI
 from pydantic import BaseModel, Field
@@ -12,12 +13,12 @@ logger = logging.getLogger(__name__)
 app = FastAPI()
 
 
-MESSAGES = {}
+MESSAGES: Dict[ItemHash, Dict[str, Any]] = {}
 
 
 @app.get("/api/v0/messages.json")
 async def get_messages(hashes: Optional[str], page: int = 1, pagination: int = 20):
-    hashes = hashes.split(",")
+    hashes = [ItemHash(h) for h in hashes.split(",")] if hashes is not None else []
     messages = [MESSAGES[item_hash] for item_hash in hashes if item_hash in MESSAGES]
     paginated_messages = messages[(page - 1) * pagination : page * pagination]
 


### PR DESCRIPTION
Problem: the codebase has type hints but we do not check them in the CI pipeline.

Solution: add a type check step with mypy.

Fixed the following issues:
- the generate/publish steps now check for exceptions before returning instead of checking in the next function. This allows to simplify the type hints for return values.
- The response hash/random bytes are now split in published/unpublished versions to ensure that the message hash is present in the API responses.