### PR TITLE
Internal: executor selection policy system

### DIFF
--- a/src/aleph_vrf/coordinator/executor_selection.py
+++ b/src/aleph_vrf/coordinator/executor_selection.py
@@ -1,0 +1,89 @@
+import abc
+import json
+from pathlib import Path
+from typing import List, Dict, Any, AsyncIterator
+import random
+
+import aiohttp
+from aleph_message.models import ItemHash
+
+from aleph_vrf.models import Executor, Node, AlephExecutor, ComputeResourceNode
+from aleph_vrf.settings import settings
+
+
+class ExecutorSelectionPolicy(abc.ABC):
+    @abc.abstractmethod
+    async def select_executors(self, nb_executors: int) -> List[Executor]:
+        ...
+
+
+async def _get_corechannel_aggregate() -> Dict[str, Any]:
+    async with aiohttp.ClientSession(settings.API_HOST) as session:
+        url = (
+            f"/api/v0/aggregates/{settings.CORECHANNEL_AGGREGATE_ADDRESS}.json?"
+            f"keys={settings.CORECHANNEL_AGGREGATE_KEY}"
+        )
+        async with session.get(url) as response:
+            if response.status != 200:
+                raise ValueError(f"CRN list not available")
+
+            return await response.json()
+
+
+class ExecuteOnAleph(ExecutorSelectionPolicy):
+    def __init__(self, vm_function: ItemHash):
+        self.vm_function = vm_function
+
+    @staticmethod
+    async def _list_compute_nodes() -> AsyncIterator[ComputeResourceNode]:
+        content = await _get_corechannel_aggregate()
+
+        if (
+            not content["data"]["corechannel"]
+            or not content["data"]["corechannel"]["resource_nodes"]
+        ):
+            raise ValueError(f"Bad CRN list format")
+
+        resource_nodes = content["data"]["corechannel"]["resource_nodes"]
+
+        for resource_node in resource_nodes:
+            # Filter nodes by score, with linked status
+            if resource_node["status"] == "linked" and resource_node["score"] > 0.9:
+                node_address = resource_node["address"].strip("/")
+                node = ComputeResourceNode(
+                    hash=resource_node["hash"],
+                    address=node_address,
+                    score=resource_node["score"],
+                )
+                yield node
+
+    @staticmethod
+    def _get_unauthorized_nodes() -> List[str]:
+        unauthorized_nodes_list_path = Path(__file__).with_name(
+            "unauthorized_node_list.json"
+        )
+        if unauthorized_nodes_list_path.is_file():
+            with open(unauthorized_nodes_list_path, "rb") as fd:
+                return json.load(fd)
+
+        return []
+
+    async def select_executors(self, nb_executors: int) -> List[Executor]:
+        compute_nodes = self._list_compute_nodes()
+        blacklisted_nodes = self._get_unauthorized_nodes()
+        whitelisted_nodes = (
+            node
+            async for node in compute_nodes
+            if node.address not in blacklisted_nodes
+        )
+        executors = [
+            AlephExecutor(node=node, vm_function=self.vm_function)
+            async for node in whitelisted_nodes
+        ]
+
+        if len(executors) < nb_executors:
+            raise ValueError(
+                f"Not enough CRNs linked, only {len(executors)} "
+                f"available from {nb_executors} requested"
+            )
+        return random.sample(executors, nb_executors)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -23,7 +23,7 @@ from aleph_vrf.settings import settings
 from mock_ccn import app as mock_ccn_app
 
 
-def wait_for_server(host: str, port: int, nb_retries: int = 3, wait_time: int = 0.1):
+def wait_for_server(host: str, port: int, nb_retries: int = 10, wait_time: int = 0.1):
     sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
     sock.settimeout(5)
 
@@ -33,6 +33,9 @@ def wait_for_server(host: str, port: int, nb_retries: int = 3, wait_time: int = 
             sock.connect((host, port))
         except ConnectionError:
             retries += 1
+            if retries == nb_retries:
+                raise
+
             sleep(wait_time)
             continue
 


### PR DESCRIPTION
Problem: for testing, we wish to switch between different ways of selecting executors (ex: repeat tests on a specific list of CRNs, use local executors for integration tests).

Solution: introduce the `ExecutorSelectionPolicy` class. Using this class, the caller can parameterize the way executors are selected, blacklisted, etc.