### PR TITLE
Internal: coordinator tests

### DIFF
--- a/src/aleph_vrf/coordinator/executor_selection.py
+++ b/src/aleph_vrf/coordinator/executor_selection.py
@@ -87,3 +87,18 @@ class ExecuteOnAleph(ExecutorSelectionPolicy):
                 f"available from {nb_executors} requested"
             )
         return random.sample(executors, nb_executors)
+
+
+class UsePredeterminedExecutors(ExecutorSelectionPolicy):
+    def __init__(self, executors: List[Executor]):
+        self.executors = executors
+
+    async def select_executors(self, nb_executors: int) -> List[Executor]:
+        if len(self.executors) < nb_executors:
+            raise ValueError(
+                f"Not enough nodes available, only {len(self.executors)} "
+                f"available from {nb_executors} requested"
+            )
+
+        # If we request fewer executors than available, return the N first executors.
+        return self.executors[:nb_executors]

--- a/src/aleph_vrf/coordinator/main.py
+++ b/src/aleph_vrf/coordinator/main.py
@@ -14,7 +14,7 @@ from fastapi import FastAPI
 
 logger.debug("local imports")
 from aleph_vrf.coordinator.vrf import generate_vrf
-from aleph_vrf.models import APIResponse, VRFResponse
+from aleph_vrf.models import APIResponse, PublishedVRFResponse
 
 logger.debug("imports done")
 
@@ -38,7 +38,7 @@ async def receive_vrf() -> APIResponse:
     private_key = get_fallback_private_key()
     account = ETHAccount(private_key=private_key)
 
-    response: Union[VRFResponse, Dict[str, str]]
+    response: Union[PublishedVRFResponse, Dict[str, str]]
 
     try:
         response = await generate_vrf(account)

--- a/src/aleph_vrf/models.py
+++ b/src/aleph_vrf/models.py
@@ -160,7 +160,25 @@ class VRFResponse(BaseModel):
     request_id: RequestId
     nodes: List[CRNVRFResponse]
     random_number: str
-    message_hash: Optional[ItemHash] = None
+
+
+class PublishedVRFResponse(VRFResponse):
+    message_hash: ItemHash
+
+    @classmethod
+    def from_vrf_response(
+        cls, vrf_response: VRFResponse, message_hash: ItemHash
+    ) -> "PublishedVRFResponse":
+        return cls(
+            nb_bytes=vrf_response.nb_bytes,
+            nb_executors=vrf_response.nb_executors,
+            nonce=vrf_response.nonce,
+            vrf_function=vrf_response.vrf_function,
+            request_id=vrf_response.request_id,
+            nodes=vrf_response.nodes,
+            random_number=vrf_response.random_number,
+            message_hash=message_hash,
+        )
 
 
 M = TypeVar("M", bound=BaseModel)

--- a/tests/coordinator/test_integration_lib.py
+++ b/tests/coordinator/test_integration_lib.py
@@ -1,0 +1,239 @@
+from typing import Tuple, Dict, List
+
+import pytest
+from aleph.sdk import AlephClient
+from aleph.sdk.chains.common import generate_key
+from aleph.sdk.chains.ethereum import ETHAccount
+from aleph_message.models import PostMessage, ItemHash
+
+from aleph_vrf.coordinator.executor_selection import UsePredeterminedExecutors
+from aleph_vrf.coordinator.vrf import generate_vrf, post_node_vrf
+from aleph_vrf.coordinator.vrf import send_generate_requests
+from aleph_vrf.models import (
+    Executor,
+    Node,
+    VRFResponse,
+    PublishedVRFResponse,
+    PublishedVRFResponseHash,
+    PublishedVRFRandomBytes,
+)
+from aleph_vrf.types import RequestId
+from aleph_vrf.utils import xor_all, bytes_to_int, binary_to_bytes, verify
+
+
+@pytest.fixture
+def mock_account() -> ETHAccount:
+    private_key = generate_key()
+    return ETHAccount(private_key=private_key)
+
+
+def assert_vrf_response_equal(
+    vrf_response: VRFResponse, expected_vrf_response: VRFResponse
+) -> None:
+    assert vrf_response.nb_bytes == expected_vrf_response.nb_bytes
+    assert vrf_response.nonce == expected_vrf_response.nonce
+    assert vrf_response.request_id == expected_vrf_response.request_id
+    assert vrf_response.vrf_function == expected_vrf_response.vrf_function
+    assert vrf_response.request_id == expected_vrf_response.request_id
+    assert vrf_response.random_number == expected_vrf_response.random_number
+
+    assert len(vrf_response.nodes) == len(expected_vrf_response.nodes)
+    expected_nodes_by_execution_id = {
+        node.execution_id: node for node in expected_vrf_response.nodes
+    }
+
+    for executor_response in vrf_response.nodes:
+        expected_executor_response = expected_nodes_by_execution_id[
+            executor_response.execution_id
+        ]
+        assert executor_response.url == expected_executor_response.url
+        assert executor_response.execution_id == expected_executor_response.execution_id
+        assert (
+            executor_response.random_number == expected_executor_response.random_number
+        )
+        assert (
+            executor_response.random_bytes_hash
+            == expected_executor_response.random_bytes_hash
+        )
+        assert (
+            executor_response.generation_message_hash
+            == expected_executor_response.generation_message_hash
+        )
+        assert (
+            executor_response.publish_message_hash
+            == expected_executor_response.publish_message_hash
+        )
+
+
+async def assert_aleph_message_matches_vrf_response(
+    ccn_url: str,
+    vrf_response: PublishedVRFResponse,
+) -> PostMessage:
+    assert vrf_response.message_hash
+
+    async with AlephClient(api_server=ccn_url) as client:
+        message = await client.get_message(
+            vrf_response.message_hash, message_type=PostMessage
+        )
+
+    message_vrf_response = VRFResponse.parse_obj(message.content.content)
+    assert_vrf_response_equal(message_vrf_response, vrf_response)
+
+    return message
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("executor_servers", [3], indirect=True)
+@pytest.mark.parametrize("nb_executors,nb_bytes", [(3, 32), (2, 16)])
+async def test_normal_flow(
+    mock_account: ETHAccount,
+    mock_ccn: str,
+    executor_servers: Tuple[str],
+    nb_executors: int,
+    nb_bytes: int,
+):
+    executors = [Executor(node=Node(address=address)) for address in executor_servers]
+
+    vrf_response = await generate_vrf(
+        account=mock_account,
+        nb_executors=nb_executors,
+        nb_bytes=nb_bytes,
+        aleph_api_server=mock_ccn,
+        executor_selection_policy=UsePredeterminedExecutors(executors),
+    )
+    assert vrf_response.nb_executors == nb_executors
+    assert len(vrf_response.nodes) == nb_executors
+    assert vrf_response.nb_bytes == nb_bytes
+    # TODO: determine if this check makes sense as leading zeroes get removed.
+    # assert int(vrf_response.random_number).bit_length() == nb_bytes * 8
+
+    for executor_response in vrf_response.nodes:
+        assert verify(
+            random_bytes=binary_to_bytes(executor_response.random_bytes),
+            nonce=vrf_response.nonce,
+            random_hash=executor_response.random_bytes_hash,
+        )
+
+    # Check that we can rebuild the random number using the executor responses
+    random_bytes = [
+        binary_to_bytes(executor_response.random_bytes)
+        for executor_response in vrf_response.nodes
+    ]
+    random_number_bytes = xor_all(random_bytes)
+    random_number = bytes_to_int(random_number_bytes)
+    assert int(vrf_response.random_number) == random_number
+
+    # Check that VRF response posted on the network matches the API response
+    await assert_aleph_message_matches_vrf_response(
+        ccn_url=mock_ccn, vrf_response=vrf_response
+    )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("executor_servers", [3], indirect=True)
+@pytest.mark.parametrize("nb_bytes", [32])
+async def test_unresponsive_executor(
+    mock_account: ETHAccount,
+    mock_ccn: str,
+    executor_servers: Tuple[str],
+    nb_bytes: int,
+):
+    """
+    Test that requesting a VRF from an unresponsive executor fails.
+    """
+
+    executors = [Executor(node=Node(address=address)) for address in executor_servers]
+    executors.append(Executor(node=Node(address="http://127.0.0.1:404")))
+
+    with pytest.raises(ValueError):
+        _vrf_response = await generate_vrf(
+            account=mock_account,
+            nb_executors=len(executors),
+            nb_bytes=len(executors),
+            aleph_api_server=mock_ccn,
+            executor_selection_policy=UsePredeterminedExecutors(executors),
+        )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("executor_servers", [3], indirect=True)
+async def test_malicious_executor(
+    mock_account: ETHAccount,
+    mock_ccn: str,
+    executor_servers: Tuple[str],
+    malicious_executor: str,
+):
+    """
+    Test that requesting a VRF from a malicious executor fails.
+    In this case, the executor will send a random number that does not match the hash
+    sent back in /generate.
+    """
+
+    nb_bytes = 32
+    executors = [Executor(node=Node(address=address)) for address in executor_servers]
+    executors.append(Executor(node=Node(address=malicious_executor)))
+
+    with pytest.raises(ValueError) as e:
+        _vrf_response = await generate_vrf(
+            account=mock_account,
+            nb_executors=len(executors),
+            nb_bytes=nb_bytes,
+            aleph_api_server=mock_ccn,
+            executor_selection_policy=UsePredeterminedExecutors(executors),
+        )
+
+    print(e)
+
+
+async def send_generate_requests_and_call_publish(
+    executors: List[Executor],
+    request_item_hash: ItemHash,
+    request_id: RequestId,
+) -> Dict[Executor, PublishedVRFResponseHash]:
+    generate_response = await send_generate_requests(
+        executors=executors, request_item_hash=request_item_hash, request_id=request_id
+    )
+
+    for executor, response in generate_response.items():
+        random_number = await post_node_vrf(
+            f"{executor.api_url}/publish/{response.message_hash}",
+            PublishedVRFRandomBytes,
+        )
+        print(random_number)
+        # We're only interested in one response for this test
+        break
+
+    return generate_response
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("executor_servers", [3], indirect=True)
+@pytest.mark.parametrize("nb_bytes", [32])
+async def test_call_publish_before_coordinator(
+    mock_account: ETHAccount,
+    mock_ccn: str,
+    executor_servers: Tuple[str],
+    nb_bytes: int,
+    mocker,
+):
+    """
+    Mocks an attack attempt where an outsider calls POST /publish on an executor before the coordinator does.
+    This should result in the coordinator call failing and an exception to be raised.
+    """
+
+    # TODO
+    ...
+    mocker.patch(
+        "aleph_vrf.coordinator.vrf.send_generate_requests",
+        send_generate_requests_and_call_publish,
+    )
+    executors = [Executor(node=Node(address=address)) for address in executor_servers]
+
+    with pytest.raises(ValueError):
+        _vrf_response = await generate_vrf(
+            account=mock_account,
+            nb_executors=len(executors),
+            nb_bytes=len(executors),
+            aleph_api_server=mock_ccn,
+            executor_selection_policy=UsePredeterminedExecutors(executors),
+        )

--- a/tests/malicious_executor.py
+++ b/tests/malicious_executor.py
@@ -1,0 +1,64 @@
+import logging
+import sys
+
+from aleph_vrf.executor.main import authenticated_aleph_client
+
+# Annotated is only available in Python 3.9+
+if sys.version_info < (3, 9):
+    from typing_extensions import Annotated
+else:
+    from typing import Annotated
+
+logger = logging.getLogger(__name__)
+
+from aleph.sdk.client import AuthenticatedAlephClient
+from aleph.sdk.vm.app import AlephApp
+from aleph_message.models import ItemHash
+
+from fastapi import FastAPI, Depends
+
+from aleph_vrf.models import (
+    APIResponse,
+    PublishedVRFResponseHash,
+    PublishedVRFRandomBytes,
+)
+from aleph_vrf.utils import bytes_to_binary
+
+
+http_app = FastAPI()
+app = AlephApp(http_app=http_app)
+
+
+@app.post("/generate/{vrf_request}")
+async def receive_generate(
+    vrf_request: ItemHash,
+    aleph_client: Annotated[
+        AuthenticatedAlephClient, Depends(authenticated_aleph_client)
+    ],
+) -> APIResponse[PublishedVRFResponseHash]:
+    from aleph_vrf.executor.main import receive_generate as real_receive_generate
+
+    return await real_receive_generate(
+        vrf_request=vrf_request, aleph_client=aleph_client
+    )
+
+
+@app.post("/publish/{hash_message}")
+async def receive_publish(
+    hash_message: ItemHash,
+    aleph_client: Annotated[
+        AuthenticatedAlephClient, Depends(authenticated_aleph_client)
+    ],
+) -> APIResponse[PublishedVRFRandomBytes]:
+    from aleph_vrf.executor.main import receive_publish as real_receive_publish
+
+    api_response = await real_receive_publish(
+        hash_message=hash_message, aleph_client=aleph_client
+    )
+    # Replace the generated random number with a hardcoded value
+    random_number = 123456789
+    api_response.data.random_number = str(random_number)
+    api_response.data.random_bytes = bytes_to_binary(
+        random_number.to_bytes(length=32, byteorder="big")
+    )
+    return api_response


### PR DESCRIPTION
Problem: there are no unit/integration tests for the coordinator.

Solution: add integration tests for the library mode of the coordinator. These tests validate the behaviour of the coordinator under different scenarios (normal operation, node outages, malicious node, attack attempts, etc).