### PR TITLE
Feature: allow the user to specify a private key

### DIFF
--- a/src/aleph_vrf/coordinator/main.py
+++ b/src/aleph_vrf/coordinator/main.py
@@ -1,6 +1,8 @@
 import logging
 from typing import Dict, Union
 
+from aleph_vrf.settings import settings
+
 logger = logging.getLogger(__name__)
 
 logger.debug("import aleph_client")
@@ -35,8 +37,7 @@ async def index():
 
 @app.post("/vrf")
 async def receive_vrf() -> APIResponse:
-    private_key = get_fallback_private_key()
-    account = ETHAccount(private_key=private_key)
+    account = settings.aleph_account()
 
     response: Union[PublishedVRFResponse, Dict[str, str]]
 

--- a/src/aleph_vrf/executor/main.py
+++ b/src/aleph_vrf/executor/main.py
@@ -52,9 +52,7 @@ app = AlephApp(http_app=http_app)
 
 
 async def authenticated_aleph_client() -> AuthenticatedAlephClient:
-    private_key = get_fallback_private_key()
-    account = ETHAccount(private_key=private_key)
-
+    account = settings.aleph_account()
     async with AuthenticatedAlephClient(
         account=account, api_server=settings.API_HOST
     ) as client:

--- a/src/aleph_vrf/settings.py
+++ b/src/aleph_vrf/settings.py
@@ -1,3 +1,8 @@
+from typing import Optional
+
+from aleph.sdk.chains.common import get_fallback_private_key
+from aleph.sdk.chains.ethereum import ETHAccount
+from hexbytes import HexBytes
 from pydantic import BaseSettings, Field, HttpUrl
 
 
@@ -17,12 +22,22 @@ class Settings(BaseSettings):
         default="4992b4127d296b240bbb73058daea9bca09f717fa94767d6f4dc3ef53b4ef5ce",
         description="VRF function to use.",
     )
-    NB_EXECUTORS: int = Field(
-        default=32, description="Number of executors to use."
-    )
+    NB_EXECUTORS: int = Field(default=32, description="Number of executors to use.")
     NB_BYTES: int = Field(
         default=32, description="Number of bytes of the generated random number."
     )
+    ETHEREUM_PRIVATE_KEY: Optional[str] = Field(
+        default=None, description="Application private key to post to aleph.im."
+    )
+
+    def private_key(self) -> HexBytes:
+        if self.ETHEREUM_PRIVATE_KEY:
+            return HexBytes(self.ETHEREUM_PRIVATE_KEY)
+
+        return HexBytes(get_fallback_private_key())
+
+    def aleph_account(self) -> ETHAccount:
+        return ETHAccount(self.private_key())
 
     class Config:
         env_prefix = "ALEPH_VRF_"


### PR DESCRIPTION
Problem: the private key is generated automatically, leaving no control to the user.

Solution: allow the user to specify a private key through the settings, as is often done in other aleph.im applications.

This feature helps fixing a concurrency bug in the integration tests caused by concurrent calls to `get_fallback_private_key()` attempting to create a symlink at the same time. We now generate a private key in the fixture.