### PR TITLE
Fix: bypass VM connector when running in aleph.im VMs

### DIFF
--- a/src/aleph_vrf/coordinator/vrf.py
+++ b/src/aleph_vrf/coordinator/vrf.py
@@ -147,7 +147,10 @@ async def generate_vrf(
     vrf_function = vrf_function or settings.FUNCTION
 
     async with AuthenticatedAlephClient(
-        account=account, api_server=aleph_api_server or settings.API_HOST
+        account=account,
+        api_server=aleph_api_server or settings.API_HOST,
+        # Avoid going through the VM connector on aleph.im CRNs
+        allow_unix_sockets=False,
     ) as aleph_client:
         return await _generate_vrf(
             aleph_client=aleph_client,

--- a/src/aleph_vrf/executor/main.py
+++ b/src/aleph_vrf/executor/main.py
@@ -55,7 +55,10 @@ app = AlephApp(http_app=http_app)
 async def authenticated_aleph_client() -> AuthenticatedAlephClient:
     account = settings.aleph_account()
     async with AuthenticatedAlephClient(
-        account=account, api_server=settings.API_HOST
+        account=account,
+        api_server=settings.API_HOST,
+        # Avoid going through the VM connector on aleph.im CRNs
+        allow_unix_sockets=False,
     ) as client:
         yield client
 
@@ -112,9 +115,7 @@ async def receive_generate(
             detail=f"A random number has already been generated for request {vrf_request_hash}",
         )
 
-    generated_bytes, hashed_bytes = generate(
-        vrf_request.nb_bytes, vrf_request.nonce
-    )
+    generated_bytes, hashed_bytes = generate(vrf_request.nb_bytes, vrf_request.nonce)
     SAVED_GENERATED_BYTES[execution_id] = generated_bytes
     ANSWERED_REQUESTS.add(vrf_request.request_id)
 

--- a/src/aleph_vrf/settings.py
+++ b/src/aleph_vrf/settings.py
@@ -19,7 +19,7 @@ class Settings(BaseSettings):
         default="corechannel", description="Key for the `corechannel` aggregate."
     )
     FUNCTION: str = Field(
-        default="5b899161b368d21b998a26bf2f580c03f5da7ee2bb70c71597f0972c5af7aa5e",
+        default="c52d6586837b0992d3043d7d0dbe8f49b180911e8c3a87c732f8dbcef2c254ab",
         description="VRF function to use.",
     )
     NB_EXECUTORS: int = Field(default=32, description="Number of executors to use.")


### PR DESCRIPTION
Problem: the current implementation goes through the VM connector to send aleph.im messages from the VMs, resulting in a) using the private key of the node and b) ending up with a 405 HTTP error.

Solution: disable the usage of the Unix socket (again).