### PR TITLE
Allow use major versions of Aleph SDK

### DIFF
--- a/deployment/deploy_vrf_vms.py
+++ b/deployment/deploy_vrf_vms.py
@@ -7,7 +7,7 @@ from pathlib import Path
 from tempfile import TemporaryDirectory
 from typing import Optional, Tuple, Dict
 
-from aleph.sdk import AuthenticatedAlephClient
+from aleph.sdk.client import AuthenticatedAlephHttpClient
 from aleph.sdk.chains.common import get_fallback_private_key
 from aleph.sdk.chains.ethereum import ETHAccount
 from aleph_message.models import ItemHash, ProgramMessage
@@ -30,7 +30,7 @@ def mksquashfs(path: Path, destination: Path) -> None:
 
 
 async def upload_dir_as_volume(
-    aleph_client: AuthenticatedAlephClient,
+    aleph_client: AuthenticatedAlephHttpClient,
     dir_path: Path,
     channel: str,
     volume_path: Optional[Path] = None,
@@ -52,7 +52,7 @@ async def upload_dir_as_volume(
 
 
 async def deploy_python_program(
-    aleph_client: AuthenticatedAlephClient,
+    aleph_client: AuthenticatedAlephHttpClient,
     code_volume_hash: ItemHash,
     entrypoint: str,
     venv_hash: ItemHash,
@@ -101,7 +101,7 @@ async def deploy_vrf(
     account = ETHAccount(private_key)
     channel = "vrf-tests"
 
-    async with AuthenticatedAlephClient(
+    async with AuthenticatedAlephHttpClient(
         account=account, api_server=settings.API_HOST
     ) as aleph_client:
         # Upload the code and venv volumes

--- a/setup.cfg
+++ b/setup.cfg
@@ -48,7 +48,7 @@ package_dir =
 # For more information, check out https://semver.org/.
 install_requires =
     aiohttp
-    aleph-sdk-python>=0.8.0
+    aleph-sdk-python~=0.8
     hexbytes
     fastapi>=0.95.1
     importlib-metadata; python_version<"3.8"

--- a/setup.cfg
+++ b/setup.cfg
@@ -48,7 +48,7 @@ package_dir =
 # For more information, check out https://semver.org/.
 install_requires =
     aiohttp
-    aleph-sdk-python==0.7.0
+    aleph-sdk-python>=0.7.0
     hexbytes
     fastapi>=0.95.1
     importlib-metadata; python_version<"3.8"

--- a/setup.cfg
+++ b/setup.cfg
@@ -48,7 +48,7 @@ package_dir =
 # For more information, check out https://semver.org/.
 install_requires =
     aiohttp
-    aleph-sdk-python~=0.8
+    aleph-sdk-python~=0.8.0
     hexbytes
     fastapi>=0.95.1
     importlib-metadata; python_version<"3.8"

--- a/setup.cfg
+++ b/setup.cfg
@@ -48,7 +48,7 @@ package_dir =
 # For more information, check out https://semver.org/.
 install_requires =
     aiohttp
-    aleph-sdk-python>=0.7.0
+    aleph-sdk-python>=0.8.0
     hexbytes
     fastapi>=0.95.1
     importlib-metadata; python_version<"3.8"

--- a/src/aleph_vrf/coordinator/vrf.py
+++ b/src/aleph_vrf/coordinator/vrf.py
@@ -7,7 +7,7 @@ from uuid import uuid4
 
 import aiohttp
 from aleph.sdk.chains.ethereum import ETHAccount
-from aleph.sdk.client import AuthenticatedAlephClient
+from aleph.sdk.client import AuthenticatedAlephHttpClient
 from aleph_message.models import ItemHash
 from aleph_message.status import MessageStatus
 from hexbytes import HexBytes
@@ -67,7 +67,7 @@ async def post_executor_api_request(url: str, model: Type[M]) -> M:
 
 
 async def _generate_vrf(
-    aleph_client: AuthenticatedAlephClient,
+    aleph_client: AuthenticatedAlephHttpClient,
     nb_executors: int,
     nb_bytes: int,
     vrf_function: ItemHash,
@@ -144,7 +144,7 @@ async def generate_vrf(
 ):
     vrf_function = vrf_function or settings.FUNCTION
 
-    async with AuthenticatedAlephClient(
+    async with AuthenticatedAlephHttpClient(
         account=account,
         api_server=aleph_api_server or settings.API_HOST,
         # Avoid going through the VM connector on aleph.im CRNs
@@ -270,7 +270,7 @@ def generate_final_vrf(
 
 
 async def publish_data(
-    aleph_client: AuthenticatedAlephClient,
+    aleph_client: AuthenticatedAlephHttpClient,
     data: Union[VRFRequest, VRFResponse],
     ref: str,
 ) -> ItemHash:

--- a/src/aleph_vrf/coordinator/vrf.py
+++ b/src/aleph_vrf/coordinator/vrf.py
@@ -8,6 +8,7 @@ from uuid import uuid4
 import aiohttp
 from aleph.sdk.chains.ethereum import ETHAccount
 from aleph.sdk.client import AuthenticatedAlephHttpClient
+from aleph.sdk.query.filters import MessageFilter
 from aleph_message.models import ItemHash, MessageType, PostMessage
 from aleph_message.status import MessageStatus
 from hexbytes import HexBytes
@@ -317,7 +318,7 @@ async def publish_data(
 
 
 async def get_existing_vrf_message(
-    aleph_client: AuthenticatedAlephClient,
+    aleph_client: AuthenticatedAlephHttpClient,
     request_id: str,
 ) -> Optional[PostMessage]:
     channel = f"vrf_{request_id}"
@@ -328,9 +329,11 @@ async def get_existing_vrf_message(
     )
 
     messages = await aleph_client.get_messages(
-        message_type=MessageType.post,
-        channels=[channel],
-        refs=[ref],
+        message_filter=MessageFilter(
+            message_types=[MessageType.post],
+            channels=[channel],
+            refs=[ref],
+        )
     )
 
     if messages.messages:
@@ -343,7 +346,7 @@ async def get_existing_vrf_message(
 
 
 async def get_existing_message(
-    aleph_client: AuthenticatedAlephClient,
+    aleph_client: AuthenticatedAlephHttpClient,
     item_hash: ItemHash,
 ) -> Optional[PostMessage]:
     logger.debug(
@@ -363,7 +366,7 @@ async def get_existing_message(
 
 
 async def check_message_integrity(
-    aleph_client: AuthenticatedAlephClient, vrf_response: PublishedVRFResponse
+    aleph_client: AuthenticatedAlephHttpClient, vrf_response: PublishedVRFResponse
 ):
     logger.debug(
         f"Checking VRF response message on {aleph_client.api_server} for item_hash {vrf_response.message_hash}"

--- a/src/aleph_vrf/executor/main.py
+++ b/src/aleph_vrf/executor/main.py
@@ -20,7 +20,7 @@ from aleph_vrf.types import ExecutionId, RequestId
 logger = logging.getLogger(__name__)
 
 logger.debug("import aleph_client")
-from aleph.sdk.client import AlephClient, AuthenticatedAlephClient
+from aleph.sdk.client import AlephHttpClient, AuthenticatedAlephHttpClient
 from aleph.sdk.vm.app import AlephApp
 from aleph_message.models import ItemHash, PostMessage
 from aleph_message.status import MessageStatus
@@ -52,9 +52,9 @@ http_app = FastAPI()
 app = AlephApp(http_app=http_app)
 
 
-async def authenticated_aleph_client() -> AuthenticatedAlephClient:
+async def authenticated_aleph_client() -> AuthenticatedAlephHttpClient:
     account = settings.aleph_account()
-    async with AuthenticatedAlephClient(
+    async with AuthenticatedAlephHttpClient(
         account=account,
         api_server=settings.API_HOST,
         # Avoid going through the VM connector on aleph.im CRNs
@@ -71,7 +71,7 @@ async def index():
     }
 
 
-async def _get_message(client: AlephClient, item_hash: ItemHash) -> PostMessage:
+async def _get_message(client: AlephHttpClient, item_hash: ItemHash) -> PostMessage:
     try:
         return await client.get_message(item_hash=item_hash, message_type=PostMessage)
     except MessageNotFoundError:
@@ -93,7 +93,7 @@ async def _get_message(client: AlephClient, item_hash: ItemHash) -> PostMessage:
 async def receive_generate(
     vrf_request_hash: ItemHash,
     aleph_client: Annotated[
-        AuthenticatedAlephClient, Depends(authenticated_aleph_client)
+        AuthenticatedAlephHttpClient, Depends(authenticated_aleph_client)
     ],
 ) -> APIResponse[PublishedVRFRandomNumberHash]:
     """
@@ -150,7 +150,7 @@ async def receive_generate(
 async def receive_publish(
     message_hash: ItemHash,
     aleph_client: Annotated[
-        AuthenticatedAlephClient, Depends(authenticated_aleph_client)
+        AuthenticatedAlephHttpClient, Depends(authenticated_aleph_client)
     ],
 ) -> APIResponse[PublishedVRFRandomNumber]:
     """
@@ -195,7 +195,7 @@ async def receive_publish(
 
 
 async def publish_data(
-    aleph_client: AuthenticatedAlephClient,
+    aleph_client: AuthenticatedAlephHttpClient,
     data: Union[VRFRandomNumberHash, VRFRandomNumber],
     ref: str,
 ) -> ItemHash:

--- a/tests/coordinator/test_integration_lib.py
+++ b/tests/coordinator/test_integration_lib.py
@@ -1,7 +1,7 @@
 from typing import Tuple, Dict, List
 
 import pytest
-from aleph.sdk import AlephClient
+from aleph.sdk.client import AlephHttpClient
 from aleph.sdk.chains.common import generate_key
 from aleph.sdk.chains.ethereum import ETHAccount
 from aleph_message.models import PostMessage, ItemHash
@@ -76,7 +76,7 @@ async def assert_aleph_message_matches_vrf_response(
 ) -> PostMessage:
     assert vrf_response.message_hash
 
-    async with AlephClient(api_server=ccn_url) as client:
+    async with AlephHttpClient(api_server=ccn_url) as client:
         message = await client.get_message(
             vrf_response.message_hash, message_type=PostMessage
         )

--- a/tests/executor/test_integration.py
+++ b/tests/executor/test_integration.py
@@ -5,7 +5,7 @@ from typing import Dict, Any, Union, Tuple
 import aiohttp
 import pytest
 import pytest_asyncio
-from aleph.sdk import AlephClient
+from aleph.sdk.client import AlephHttpClient
 from aleph_message.models import (
     ItemType,
     MessageType,
@@ -156,7 +156,7 @@ async def assert_aleph_message_matches_random_number_hash(
 ) -> PostMessage:
     assert random_number_hash.message_hash
 
-    async with AlephClient(api_server=ccn_url) as client:
+    async with AlephHttpClient(api_server=ccn_url) as client:
         message = await client.get_message(
             random_number_hash.message_hash, message_type=PostMessage
         )
@@ -182,7 +182,7 @@ async def assert_aleph_message_matches_random_number(
     ccn_url: Any,  # aiohttp does not expose its URL type
     random_number: PublishedVRFRandomNumber,
 ) -> PostMessage:
-    async with AlephClient(api_server=ccn_url) as client:
+    async with AlephHttpClient(api_server=ccn_url) as client:
         message = await client.get_message(
             random_number.message_hash, message_type=PostMessage
         )

--- a/tests/malicious_executor.py
+++ b/tests/malicious_executor.py
@@ -16,7 +16,7 @@ else:
 
 logger = logging.getLogger(__name__)
 
-from aleph.sdk.client import AuthenticatedAlephClient
+from aleph.sdk.client import AuthenticatedAlephHttpClient
 from aleph.sdk.vm.app import AlephApp
 from aleph_message.models import ItemHash
 
@@ -36,7 +36,7 @@ app = AlephApp(http_app=http_app)
 async def receive_generate(
     vrf_request_hash: ItemHash,
     aleph_client: Annotated[
-        AuthenticatedAlephClient, Depends(authenticated_aleph_client)
+        AuthenticatedAlephHttpClient, Depends(authenticated_aleph_client)
     ],
 ) -> APIResponse[PublishedVRFRandomNumberHash]:
     from aleph_vrf.executor.main import receive_generate as real_receive_generate
@@ -50,7 +50,7 @@ async def receive_generate(
 async def receive_publish(
     message_hash: ItemHash,
     aleph_client: Annotated[
-        AuthenticatedAlephClient, Depends(authenticated_aleph_client)
+        AuthenticatedAlephHttpClient, Depends(authenticated_aleph_client)
     ],
 ) -> APIResponse[PublishedVRFRandomNumber]:
     from aleph_vrf.executor.main import receive_publish as real_receive_publish

--- a/tests/mock_ccn.py
+++ b/tests/mock_ccn.py
@@ -9,7 +9,7 @@ from typing import Optional, Dict, Any, List
 
 from aleph_message.models import ItemHash
 from aleph_message.status import MessageStatus
-from fastapi import FastAPI
+from fastapi import FastAPI, HTTPException
 from pydantic import BaseModel, Field
 
 logger = logging.getLogger(__name__)
@@ -22,6 +22,9 @@ MESSAGES: Dict[ItemHash, Dict[str, Any]] = {}
 
 @app.get("/api/v0/messages.json")
 async def get_messages(hashes: Optional[str], page: int = 1, pagination: int = 20):
+    """
+    Mock messages.json endpoint
+    """
     hashes = [ItemHash(h) for h in hashes.split(",")] if hashes is not None else []
     messages = [MESSAGES[item_hash] for item_hash in hashes if item_hash in MESSAGES]
     paginated_messages = messages[(page - 1) * pagination : page * pagination]
@@ -33,6 +36,26 @@ async def get_messages(hashes: Optional[str], page: int = 1, pagination: int = 2
         "pagination_total": len(messages),
         "pagination_item": "messages",
     }
+
+
+class MessageResponse(BaseModel):
+    message: Dict[str, Any]
+    status: str
+
+
+@app.get("/api/v0/messages/{item_hash}")
+async def get_message(item_hash: str):
+    """
+    Mock individual view message endpoint
+    """
+    message = MESSAGES.get(ItemHash(item_hash))
+    if not message:
+        raise HTTPException(status_code=404, detail="Message not found")
+
+    return MessageResponse(
+        message=message,
+        status="processed"
+    )
 
 
 class PubMessageRequest(BaseModel):


### PR DESCRIPTION
Problem: Having a strong dependency to an exact aleph-python-sdk library version creates a dependency hell.

Solution: Allow to use the same and major version of aleph-python-sdk library.