### PR TITLE
Allow send custom VRF `request_id`

### DIFF
--- a/src/aleph_vrf/coordinator/executor_selection.py
+++ b/src/aleph_vrf/coordinator/executor_selection.py
@@ -1,14 +1,14 @@
 import abc
 import json
-from pathlib import Path
-from typing import List, Dict, Any, AsyncIterator
 import random
+from pathlib import Path
+from typing import Any, AsyncIterator, Dict, List
 
 import aiohttp
 from aleph_message.models import ItemHash
 
-from aleph_vrf.exceptions import NotEnoughExecutors, AlephNetworkError
-from aleph_vrf.models import Executor, Node, AlephExecutor, ComputeResourceNode
+from aleph_vrf.exceptions import AlephNetworkError, NotEnoughExecutors
+from aleph_vrf.models import AlephExecutor, ComputeResourceNode, Executor, Node
 from aleph_vrf.settings import settings
 
 

--- a/src/aleph_vrf/coordinator/main.py
+++ b/src/aleph_vrf/coordinator/main.py
@@ -14,7 +14,7 @@ from fastapi import FastAPI
 
 logger.debug("local imports")
 from aleph_vrf.coordinator.vrf import generate_vrf
-from aleph_vrf.models import APIResponse, PublishedVRFResponse, APIError
+from aleph_vrf.models import APIError, APIResponse, PublishedVRFResponse
 
 logger.debug("imports done")
 

--- a/src/aleph_vrf/coordinator/main.py
+++ b/src/aleph_vrf/coordinator/main.py
@@ -12,7 +12,7 @@ from aleph.sdk.vm.app import AlephApp
 from aleph.sdk.vm.cache import VmCache
 
 logger.debug("import fastapi")
-from fastapi import FastAPI
+from fastapi import FastAPI, HTTPException
 
 logger.debug("local imports")
 from aleph_vrf.coordinator.vrf import generate_vrf
@@ -41,7 +41,7 @@ async def index():
 
 @app.post("/vrf")
 async def receive_vrf(
-    request: VRFRequest,
+    request: Optional[VRFRequest] = None,
 ) -> APIResponse[Union[PublishedVRFResponse, APIError]]:
     """
     Goes through the VRF random number generation process and returns a random number
@@ -56,6 +56,6 @@ async def receive_vrf(
     try:
         response = await generate_vrf(account=account, request_id=request_id)
     except Exception as err:
-        response = APIError(error=str(err))
+        raise HTTPException(status_code=500, detail=str(err))
 
     return APIResponse(data=response)

--- a/src/aleph_vrf/coordinator/vrf.py
+++ b/src/aleph_vrf/coordinator/vrf.py
@@ -355,22 +355,26 @@ async def get_existing_message(
     )
 
     if not message:
-        logger.debug(f"Existing VRF message for item_hash {item_hash} not found")
         raise AlephNetworkError(
             f"Message could not be read for item_hash {message.item_hash}"
+        )
+
+    if status != MessageStatus.PROCESSED:
+        raise AlephNetworkError(
+            f"Message found for item_hash {message.item_hash} not in processed status"
         )
 
     return message
 
 
 async def check_message_integrity(
-    aleph_client: AuthenticatedAlephClient, message: PublishedVRFResponse
+    aleph_client: AuthenticatedAlephClient, vrf_response: PublishedVRFResponse
 ):
     logger.debug(
-        f"Checking VRF response message on {aleph_client.api_server} for item_hash {message.message_hash}"
+        f"Checking VRF response message on {aleph_client.api_server} for item_hash {vrf_response.message_hash}"
     )
 
-    for executor in message.executors:
+    for executor in vrf_response.executors:
         generation_message = await get_existing_message(
             aleph_client, executor.generation_message_hash
         )

--- a/src/aleph_vrf/coordinator/vrf.py
+++ b/src/aleph_vrf/coordinator/vrf.py
@@ -327,16 +327,16 @@ async def get_existing_vrf_message(
         f"Getting VRF messages on {aleph_client.api_server} from request id {request_id}"
     )
 
-    messages, status = await aleph_client.get_messages(
+    messages = await aleph_client.get_messages(
         message_type=MessageType.post,
         channels=[channel],
         refs=[ref],
     )
 
-    if messages:
-        if len(messages) > 1:
+    if messages.messages:
+        if len(messages.messages) > 1:
             logger.warning(f"Multiple VRF messages found for request id {request_id}")
-        return messages[0]
+        return messages.messages[0]
     else:
         logger.debug(f"Existing VRF message for request id {request_id} not found")
         return None
@@ -350,18 +350,13 @@ async def get_existing_message(
         f"Getting VRF message on {aleph_client.api_server} for item_hash {item_hash}"
     )
 
-    message, status = await aleph_client.get_message(
+    message = await aleph_client.get_message(
         item_hash=item_hash,
     )
 
     if not message:
         raise AlephNetworkError(
             f"Message could not be read for item_hash {message.item_hash}"
-        )
-
-    if status != MessageStatus.PROCESSED:
-        raise AlephNetworkError(
-            f"Message found for item_hash {message.item_hash} not in processed status"
         )
 
     return message

--- a/src/aleph_vrf/exceptions.py
+++ b/src/aleph_vrf/exceptions.py
@@ -1,4 +1,4 @@
-from aleph_vrf.models import Executor, PublishedVRFRandomNumber
+from aleph_vrf.models import Executor, ExecutorVRFResponse, PublishedVRFRandomNumber
 
 
 class VrfException(Exception):
@@ -72,6 +72,25 @@ class HashesDoNotMatch(VrfException):
         )
 
 
+class PublishedHashesDoNotMatch(VrfException):
+    """
+    The random number hash received from /publish is different from the one received from /generate.
+    """
+
+    def __init__(
+        self, executor: ExecutorVRFResponse, generation_hash: str, publication_hash: str
+    ):
+        self.executor = executor
+        self.generation_hash = generation_hash
+        self.publication_hash = publication_hash
+
+    def __str__(self):
+        return (
+            f"Published random number hash ({self.publication_hash})"
+            f"does not match the generated one ({self.generation_hash})."
+        )
+
+
 class HashValidationFailed(VrfException):
     """
     A random number does not match the SHA3 hash sent by the executor.
@@ -90,6 +109,29 @@ class HashValidationFailed(VrfException):
     def __str__(self):
         return (
             f"The random number published by {self.executor.api_url} "
+            f"(execution ID: {self.random_number.execution_id}) "
+            "does not match the hash."
+        )
+
+
+class PublishedHashValidationFailed(VrfException):
+    """
+    A random number does not match the SHA3 hash sent by the executor.
+    """
+
+    def __init__(
+        self,
+        random_number: PublishedVRFRandomNumber,
+        random_number_hash: str,
+        executor: ExecutorVRFResponse,
+    ):
+        self.random_number = random_number
+        self.random_number_hash = random_number_hash
+        self.executor = executor
+
+    def __str__(self):
+        return (
+            f"The random number published by {self.executor.url} "
             f"(execution ID: {self.random_number.execution_id}) "
             "does not match the hash."
         )

--- a/src/aleph_vrf/executor/main.py
+++ b/src/aleph_vrf/executor/main.py
@@ -1,6 +1,6 @@
 import logging
 import sys
-from typing import Dict, Union, Set
+from typing import Dict, Set, Union
 from uuid import uuid4
 
 from aleph_vrf.exceptions import AlephNetworkError
@@ -26,17 +26,17 @@ from aleph_message.models import ItemHash, PostMessage
 from aleph_message.status import MessageStatus
 
 logger.debug("import fastapi")
-from fastapi import FastAPI, Depends
+from fastapi import Depends, FastAPI
 
 logger.debug("local imports")
 from aleph_vrf.models import (
     APIResponse,
+    PublishedVRFRandomNumber,
+    PublishedVRFRandomNumberHash,
     VRFRandomNumber,
     VRFRandomNumberHash,
-    get_vrf_request_from_message,
     get_random_number_hash_from_message,
-    PublishedVRFRandomNumberHash,
-    PublishedVRFRandomNumber,
+    get_vrf_request_from_message,
 )
 from aleph_vrf.utils import generate
 
@@ -115,7 +115,9 @@ async def receive_generate(
             detail=f"A random number has already been generated for request {vrf_request_hash}",
         )
 
-    random_number, random_number_hash = generate(vrf_request.nb_bytes, vrf_request.nonce)
+    random_number, random_number_hash = generate(
+        vrf_request.nb_bytes, vrf_request.nonce
+    )
     GENERATED_NUMBERS[execution_id] = random_number
     ANSWERED_REQUESTS.add(vrf_request.request_id)
 

--- a/src/aleph_vrf/models.py
+++ b/src/aleph_vrf/models.py
@@ -1,14 +1,12 @@
-from typing import List
-from typing import TypeVar, Generic
+from typing import Generic, List, TypeVar
 
 import fastapi
 from aleph_message.models import ItemHash, PostMessage
 from aleph_message.models.abstract import HashableModel
-from pydantic import BaseModel
-from pydantic import ValidationError
+from pydantic import BaseModel, ValidationError
 from pydantic.generics import GenericModel
 
-from aleph_vrf.types import Nonce, RequestId, ExecutionId
+from aleph_vrf.types import ExecutionId, Nonce, RequestId
 
 
 class Node(HashableModel):
@@ -166,6 +164,20 @@ class PublishedVRFResponse(VRFResponse):
             executors=vrf_response.executors,
             random_number=vrf_response.random_number,
             message_hash=message_hash,
+        )
+
+    @classmethod
+    def from_vrf_post_message(cls, post_message: PostMessage) -> "PublishedVRFResponse":
+        vrf_response = post_message.content.content
+        return cls(
+            nb_bytes=vrf_response.nb_bytes,
+            nb_executors=vrf_response.nb_executors,
+            nonce=vrf_response.nonce,
+            vrf_function=vrf_response.vrf_function,
+            request_id=vrf_response.request_id,
+            executors=vrf_response.executors,
+            random_number=vrf_response.random_number,
+            message_hash=post_message.item_hash,
         )
 
 

--- a/src/aleph_vrf/models.py
+++ b/src/aleph_vrf/models.py
@@ -86,6 +86,21 @@ class PublishedVRFRandomNumberHash(VRFRandomNumberHash):
             message_hash=message_hash,
         )
 
+    @classmethod
+    def from_published_message(
+        cls, message: PostMessage
+    ) -> "PublishedVRFRandomNumberHash":
+        vrf_response_hash = message.content.content
+        return cls(
+            nb_bytes=vrf_response_hash.nb_bytes,
+            nonce=vrf_response_hash.nonce,
+            request_id=vrf_response_hash.request_id,
+            execution_id=vrf_response_hash.execution_id,
+            vrf_request=vrf_response_hash.vrf_request,
+            random_number_hash=vrf_response_hash.random_number_hash,
+            message_hash=message.item_hash,
+        )
+
 
 def get_random_number_hash_from_message(
     message: PostMessage,
@@ -126,6 +141,18 @@ class PublishedVRFRandomNumber(VRFRandomNumber):
             random_number=vrf_random_number.random_number,
             random_number_hash=vrf_random_number.random_number_hash,
             message_hash=message_hash,
+        )
+
+    @classmethod
+    def from_published_message(cls, message: PostMessage) -> "PublishedVRFRandomNumber":
+        vrf_random_number = message.content.content
+        return cls(
+            request_id=vrf_random_number.request_id,
+            execution_id=vrf_random_number.execution_id,
+            vrf_request=vrf_random_number.vrf_request,
+            random_number=vrf_random_number.random_number,
+            random_number_hash=vrf_random_number.random_number_hash,
+            message_hash=message.item_hash,
         )
 
 

--- a/src/aleph_vrf/models.py
+++ b/src/aleph_vrf/models.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import Generic, List, TypeVar
 
 import fastapi
@@ -75,7 +77,7 @@ class PublishedVRFRandomNumberHash(VRFRandomNumberHash):
     @classmethod
     def from_vrf_response_hash(
         cls, vrf_response_hash: VRFRandomNumberHash, message_hash: ItemHash
-    ) -> "PublishedVRFRandomNumberHash":
+    ) -> PublishedVRFRandomNumberHash:
         return cls(
             nb_bytes=vrf_response_hash.nb_bytes,
             nonce=vrf_response_hash.nonce,
@@ -89,7 +91,7 @@ class PublishedVRFRandomNumberHash(VRFRandomNumberHash):
     @classmethod
     def from_published_message(
         cls, message: PostMessage
-    ) -> "PublishedVRFRandomNumberHash":
+    ) -> PublishedVRFRandomNumberHash:
         vrf_response_hash = message.content.content
         return cls(
             nb_bytes=vrf_response_hash.nb_bytes,
@@ -133,7 +135,7 @@ class PublishedVRFRandomNumber(VRFRandomNumber):
     @classmethod
     def from_vrf_random_number(
         cls, vrf_random_number: VRFRandomNumber, message_hash: ItemHash
-    ) -> "PublishedVRFRandomNumber":
+    ) -> PublishedVRFRandomNumber:
         return cls(
             request_id=vrf_random_number.request_id,
             execution_id=vrf_random_number.execution_id,
@@ -144,7 +146,7 @@ class PublishedVRFRandomNumber(VRFRandomNumber):
         )
 
     @classmethod
-    def from_published_message(cls, message: PostMessage) -> "PublishedVRFRandomNumber":
+    def from_published_message(cls, message: PostMessage) -> PublishedVRFRandomNumber:
         vrf_random_number = message.content.content
         return cls(
             request_id=vrf_random_number.request_id,
@@ -181,7 +183,7 @@ class PublishedVRFResponse(VRFResponse):
     @classmethod
     def from_vrf_response(
         cls, vrf_response: VRFResponse, message_hash: ItemHash
-    ) -> "PublishedVRFResponse":
+    ) -> PublishedVRFResponse:
         return cls(
             nb_bytes=vrf_response.nb_bytes,
             nb_executors=vrf_response.nb_executors,
@@ -194,7 +196,7 @@ class PublishedVRFResponse(VRFResponse):
         )
 
     @classmethod
-    def from_vrf_post_message(cls, post_message: PostMessage) -> "PublishedVRFResponse":
+    def from_vrf_post_message(cls, post_message: PostMessage) -> PublishedVRFResponse:
         vrf_response = post_message.content.content
         return cls(
             nb_bytes=vrf_response.nb_bytes,

--- a/src/aleph_vrf/models.py
+++ b/src/aleph_vrf/models.py
@@ -92,7 +92,7 @@ class PublishedVRFRandomNumberHash(VRFRandomNumberHash):
     def from_published_message(
         cls, message: PostMessage
     ) -> PublishedVRFRandomNumberHash:
-        vrf_response_hash = message.content.content
+        vrf_response_hash = VRFRandomNumberHash.parse_obj(message.content.content)
         return cls(
             nb_bytes=vrf_response_hash.nb_bytes,
             nonce=vrf_response_hash.nonce,
@@ -147,7 +147,7 @@ class PublishedVRFRandomNumber(VRFRandomNumber):
 
     @classmethod
     def from_published_message(cls, message: PostMessage) -> PublishedVRFRandomNumber:
-        vrf_random_number = message.content.content
+        vrf_random_number = VRFRandomNumber.parse_obj(message.content.content)
         return cls(
             request_id=vrf_random_number.request_id,
             execution_id=vrf_random_number.execution_id,
@@ -197,7 +197,7 @@ class PublishedVRFResponse(VRFResponse):
 
     @classmethod
     def from_vrf_post_message(cls, post_message: PostMessage) -> PublishedVRFResponse:
-        vrf_response = post_message.content.content
+        vrf_response = VRFResponse.parse_obj(post_message.content.content)
         return cls(
             nb_bytes=vrf_response.nb_bytes,
             nb_executors=vrf_response.nb_executors,

--- a/src/aleph_vrf/utils.py
+++ b/src/aleph_vrf/utils.py
@@ -6,7 +6,6 @@ from utilitybelt import dev_urandom_entropy
 
 from aleph_vrf.types import Nonce
 
-
 # Used for compatibility with HexBytes or any class that inherits bytes
 BytesLike = TypeVar("BytesLike", bound="bytes")
 


### PR DESCRIPTION
Problem: Is not possible to send a custom request_id on the API, because it creates it automatically.

Solution: Allow to pass a custom request_id field. If the request_id is already used, we check it that is a good one and return it. If not, we will use it on the VRF. If it's not set, we create a new one using uuid, like before.

NOTE: This feature was requested by Ubisoft.