### PR TITLE
Hotfix - Get always last VRF message

### DIFF
--- a/src/aleph_vrf/coordinator/vrf.py
+++ b/src/aleph_vrf/coordinator/vrf.py
@@ -339,7 +339,7 @@ async def get_existing_vrf_message(
     if messages.messages:
         if len(messages.messages) > 1:
             logger.warning(f"Multiple VRF messages found for request id {request_id}")
-        return messages.messages[0]
+        return messages.messages[-1]
     else:
         logger.debug(f"Existing VRF message for request id {request_id} not found")
         return None

--- a/src/aleph_vrf/coordinator/vrf.py
+++ b/src/aleph_vrf/coordinator/vrf.py
@@ -339,7 +339,9 @@ async def get_existing_vrf_message(
     if messages.messages:
         if len(messages.messages) > 1:
             logger.warning(f"Multiple VRF messages found for request id {request_id}")
-        return messages.messages[-1]
+        return messages.messages[
+            -1
+        ]  # Always fetch the last VRF message in case there is more than 1.
     else:
         logger.debug(f"Existing VRF message for request id {request_id} not found")
         return None


### PR DESCRIPTION
Fix: Ensure to get always last VRF message in the case that exists more than 1.