### PR TITLE
Fix: Setting API_HOST did not respect SDK settings

### DIFF
--- a/deployment/deploy_vrf_vms.py
+++ b/deployment/deploy_vrf_vms.py
@@ -102,7 +102,7 @@ async def deploy_vrf(
     channel = "vrf-tests"
 
     async with AuthenticatedAlephHttpClient(
-        account=account, api_server=settings.API_HOST
+        account=account, api_server=settings.api_host
     ) as aleph_client:
         # Upload the code and venv volumes
         print("Uploading code volume...")

--- a/src/aleph_vrf/coordinator/executor_selection.py
+++ b/src/aleph_vrf/coordinator/executor_selection.py
@@ -31,7 +31,7 @@ async def _get_corechannel_aggregate() -> Dict[str, Any]:
     Returns the "corechannel" aleph.im aggregate.
     This aggregate contains an up-to-date list of staked nodes on the network.
     """
-    async with aiohttp.ClientSession(settings.API_HOST) as session:
+    async with aiohttp.ClientSession(settings.api_host) as session:
         url = (
             f"/api/v0/aggregates/{settings.CORECHANNEL_AGGREGATE_ADDRESS}.json?"
             f"keys={settings.CORECHANNEL_AGGREGATE_KEY}"

--- a/src/aleph_vrf/coordinator/vrf.py
+++ b/src/aleph_vrf/coordinator/vrf.py
@@ -168,7 +168,7 @@ async def generate_vrf(
 
     async with AuthenticatedAlephHttpClient(
         account=account,
-        api_server=aleph_api_server or settings.API_HOST,
+        api_server=aleph_api_server or settings.api_host,
         # Avoid going through the VM connector on aleph.im CRNs
         allow_unix_sockets=False,
     ) as aleph_client:

--- a/src/aleph_vrf/executor/main.py
+++ b/src/aleph_vrf/executor/main.py
@@ -56,7 +56,7 @@ async def authenticated_aleph_client() -> AuthenticatedAlephHttpClient:
     account = settings.aleph_account()
     async with AuthenticatedAlephHttpClient(
         account=account,
-        api_server=settings.API_HOST,
+        api_server=settings.api_host,
         # Avoid going through the VM connector on aleph.im CRNs
         allow_unix_sockets=False,
     ) as client:

--- a/src/aleph_vrf/settings.py
+++ b/src/aleph_vrf/settings.py
@@ -2,14 +2,16 @@ from typing import Optional
 
 from aleph.sdk.chains.common import get_fallback_private_key
 from aleph.sdk.chains.ethereum import ETHAccount
+from aleph.sdk.conf import settings as sdk_settings
 from hexbytes import HexBytes
 from pydantic import BaseSettings, Field, HttpUrl
 
 
 class Settings(BaseSettings):
-    API_HOST: HttpUrl = Field(
-        default="https://api2.aleph.im",
-        description="URL of the reference aleph.im Core Channel Node.",
+    API_HOST: Optional[HttpUrl] = Field(
+        default=None,
+        description="URL of the reference aleph.im Core Channel Node. "
+        "If None, the value from the SDK settings is used.",
     )
     CORECHANNEL_AGGREGATE_ADDRESS = Field(
         default="0xa1B3bb7d2332383D96b7796B908fB7f7F3c2Be10",
@@ -29,6 +31,10 @@ class Settings(BaseSettings):
     ETHEREUM_PRIVATE_KEY: Optional[str] = Field(
         default=None, description="Application private key to post to aleph.im."
     )
+
+    @property
+    def api_host(self) -> HttpUrl:
+        return self.API_HOST or sdk_settings.api_host
 
     def private_key(self) -> HexBytes:
         if self.ETHEREUM_PRIVATE_KEY:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,12 +6,13 @@
     - https://docs.pytest.org/en/stable/fixture.html
     - https://docs.pytest.org/en/stable/writing_plugins.html
 """
+
 import multiprocessing
 import os
 import socket
-from contextlib import contextmanager, ExitStack, AsyncExitStack
+from contextlib import AsyncExitStack, ExitStack, contextmanager
 from time import sleep
-from typing import Union, Tuple, ContextManager
+from typing import ContextManager, Tuple, Union
 
 import aiohttp
 import fastapi.applications
@@ -20,10 +21,10 @@ import pytest_asyncio
 import uvicorn
 from aleph.sdk.chains.common import generate_key
 from hexbytes import HexBytes
+from malicious_executor import app as malicious_executor_app
+from mock_ccn import app as mock_ccn_app
 
 from aleph_vrf.settings import settings
-from mock_ccn import app as mock_ccn_app
-from malicious_executor import app as malicious_executor_app
 
 
 def wait_for_server(host: str, port: int, nb_retries: int = 10, wait_time: int = 0.1):
@@ -69,19 +70,20 @@ def mock_ccn() -> str:
     host, port = "127.0.0.1", 4024
     url = f"http://{host}:{port}"
 
-    default_api_host = settings.API_HOST
+    try:
+        # Configure the mock CCN as API host. Note that `settings` must be modified as the object is
+        # already built when running all tests in the same run.
+        os.environ["ALEPH_VRF_API_HOST"] = url
+        settings.API_HOST = url
 
-    # Configure the mock CCN as API host. Note that `settings` must be modified as the object is
-    # already built when running all tests in the same run.
-    os.environ["ALEPH_VRF_API_HOST"] = url
-    settings.API_HOST = url
+        with run_http_app(app=mock_ccn_app, host=host, port=port):
+            yield url
 
-    with run_http_app(app=mock_ccn_app, host=host, port=port):
-        yield url
-
-    # Clean up settings for other tests
-    del os.environ["ALEPH_VRF_API_HOST"]
-    settings.API_HOST = default_api_host
+        # Clean up settings for other tests
+        del os.environ["ALEPH_VRF_API_HOST"]
+    finally:
+        # Restore the original settings
+        settings.API_HOST = None
 
 
 @pytest_asyncio.fixture


### PR DESCRIPTION
Users had to create a distinct `ALEPH_VRF_API_HOST` environment variable to configure it and could not use the SDK's `ALEPH_API_HOST`.
