### PR TITLE
Improve Execution VM with custom request ids

### DIFF
--- a/deployment/prepare_vrf_vms.py
+++ b/deployment/prepare_vrf_vms.py
@@ -14,13 +14,15 @@ from aleph_vrf.models import Executor
 
 async def prepare_executor_nodes(executor_item_hash: ItemHash) -> Tuple[List[Executor], List[Executor]]:
     aleph_selection_policy = ExecuteOnAleph(vm_function=executor_item_hash)
-    executors = await aleph_selection_policy.get_candidate_executors()
+    executors = await aleph_selection_policy.get_all_executors()
+    print(f"Preparing VRF VMs for {len(executors)} nodes")
     prepare_tasks = [asyncio.create_task(prepare_executor_api_request(executor.api_url))
                      for executor in executors]
 
     vrf_prepare_responses = await asyncio.gather(
         *prepare_tasks, return_exceptions=True
     )
+
     prepare_results = dict(zip(executors, vrf_prepare_responses))
 
     failed_nodes = []

--- a/src/aleph_vrf/coordinator/executor_selection.py
+++ b/src/aleph_vrf/coordinator/executor_selection.py
@@ -127,6 +127,15 @@ class ExecuteOnAleph(ExecutorSelectionPolicy):
 
         return executors
 
+    async def get_all_executors(self) -> List[VRFExecutor]:
+        compute_nodes = self._list_compute_nodes()
+        executors: List[VRFExecutor] = [
+            AlephExecutor(node=node, vm_function=self.vm_function)
+            async for node in compute_nodes
+        ]
+
+        return executors
+
 
 class UsePredeterminedExecutors(ExecutorSelectionPolicy):
     """

--- a/src/aleph_vrf/coordinator/vrf.py
+++ b/src/aleph_vrf/coordinator/vrf.py
@@ -64,16 +64,20 @@ async def post_executor_api_request(url: str, model: Type[M]) -> M:
 
 
 async def prepare_executor_api_request(url: str) -> bool:
-    async with aiohttp.ClientSession() as session:
-        async with session.get(url, timeout=120) as resp:
-            try:
+    try:
+        async with aiohttp.ClientSession() as session:
+            async with session.get(url, timeout=30) as resp:
                 resp.raise_for_status()
                 response = await resp.json()
                 return response["name"] == "vrf_generate_api"
-            except aiohttp.ClientResponseError as error:
-                raise ExecutorHttpError(
-                    url=url, status_code=resp.status, response_text=await resp.text()
-                ) from error
+    except aiohttp.ClientResponseError as error:
+        raise ExecutorHttpError(
+            url=url, status_code=resp.status, response_text=await resp.text()
+        ) from error
+    except asyncio.TimeoutError as error:
+        raise ExecutorHttpError(
+            url=url, status_code=resp.status, response_text=await resp.text()
+        ) from error
 
 
 async def _generate_vrf(

--- a/src/aleph_vrf/settings.py
+++ b/src/aleph_vrf/settings.py
@@ -19,7 +19,7 @@ class Settings(BaseSettings):
         default="corechannel", description="Key for the `corechannel` aggregate."
     )
     FUNCTION: str = Field(
-        default="f6a734dbc98659f030e1cd9c12d8ffb769deac55d42d5db5285fba099755c779",
+        default="6ad7c5ace3dfbb68954f1eea6b775d8a38610f8d0fdc48b4f1b85ccfa9795931",
         description="VRF function to use.",
     )
     NB_EXECUTORS: int = Field(default=32, description="Number of executors to use.")


### PR DESCRIPTION
Problem: Sometimes the VRF request fails and the execution cannot use the same custom request ID.

Solution: Allow to use the same request_id until it is finished completely.

Extra: Added some tweaks on the coordinator VM and on the preparation script.